### PR TITLE
AppSettingsTransform handle missing ConnectionStrings element in appsettings.json

### DIFF
--- a/src/Publish/Tasks/AppSettingsTransform.cs
+++ b/src/Publish/Tasks/AppSettingsTransform.cs
@@ -7,6 +7,8 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
 {
     public static class AppSettingsTransform
     {
+        private const string ConnectionStringsId = "ConnectionStrings";
+
         public static string GenerateDefaultAppSettingsJsonFile()
         {
             string tempFileFullPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -37,12 +39,16 @@ namespace Microsoft.NET.Sdk.Publish.Tasks
 
             string appSettingsJsonContent = File.ReadAllText(destinationAppSettingsFilePath);
             JObject appSettingsJsonObject = JObject.Parse(appSettingsJsonContent);
+            if (!appSettingsJsonObject.TryGetValue(ConnectionStringsId, out _))
+            {
+                appSettingsJsonObject[ConnectionStringsId] = new JObject();
+            }
 
             foreach (ITaskItem destinationConnectionString in destinationConnectionStrings)
             {
                 string key = destinationConnectionString.ItemSpec;
                 string Value = destinationConnectionString.GetMetadata("Value");
-                var connectionStringsObject = appSettingsJsonObject["ConnectionStrings"];
+                var connectionStringsObject = appSettingsJsonObject[ConnectionStringsId];
                 if (connectionStringsObject != null)
                 {
                     connectionStringsObject[key] = Value;

--- a/test/Publish/Tasks/AppSettingsTransformTests.cs
+++ b/test/Publish/Tasks/AppSettingsTransformTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         [InlineData("DefaultConnection", @"Server=(localdb)\mssqllocaldb;Database=defaultDB;Trusted_Connection=True;MultipleActiveResultSets=true")]
         [InlineData("EmptyConnection", @"")]
         [InlineData("", @"SomeConnectionStringValue")]
-        public void AppSettingsTransform_DoesNotFailIfConnectionStringsElementIsMissing(string connectionName, string connectionString)
+        public void AppSettingsTransform_UpdateConnectionStringEvenIfConnectionStringSectionMissing(string connectionName, string connectionString)
         {
             // Arrange
             ITaskItem[] taskItemArray = new ITaskItem[1];

--- a/test/Publish/Tasks/AppSettingsTransformTests.cs
+++ b/test/Publish/Tasks/AppSettingsTransformTests.cs
@@ -113,5 +113,34 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
                 File.Delete(destinationAppSettingsFile);
             }
         }
+
+        [Theory]
+        [InlineData("DefaultConnection", @"Server=(localdb)\mssqllocaldb;Database=defaultDB;Trusted_Connection=True;MultipleActiveResultSets=true")]
+        [InlineData("EmptyConnection", @"")]
+        [InlineData("", @"SomeConnectionStringValue")]
+        public void AppSettingsTransform_DoesNotFailIfConnectionStringsElementIsMissing(string connectionName, string connectionString)
+        {
+            // Arrange
+            ITaskItem[] taskItemArray = new ITaskItem[1];
+            var connectionstringTaskItem = new TaskItem(connectionName);
+            connectionstringTaskItem.SetMetadata("Value", connectionString);
+            taskItemArray[0] = connectionstringTaskItem;
+
+            // appSettings.json with no ConnectionStrings (empty)
+            var appsettingsFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            File.WriteAllText(appsettingsFile, "{}");
+
+            // Act 
+            AppSettingsTransform.UpdateDestinationConnectionStringEntries(appsettingsFile, taskItemArray);
+
+            // Assert
+            JToken connectionStringValue = JObject.Parse(File.ReadAllText(appsettingsFile))["ConnectionStrings"][connectionName];
+            Assert.Equal(connectionStringValue.ToString(), connectionString);
+
+            if (File.Exists(appsettingsFile))
+            {
+                File.Delete(appsettingsFile);
+            }
+        }
     }
 }


### PR DESCRIPTION
Handle the case where there are connecting strings to configure but the ConnectionStrings element is missing in the appsettings.json file. In this PR:
 - Verify if the ConnectionStrings element is missing and there are connections to configure. If this is the case, add the element to the json object.
 - Add UT for this scenario